### PR TITLE
feat: improve ws.conn handling

### DIFF
--- a/cmd/xmidt-agent/credentials.go
+++ b/cmd/xmidt-agent/credentials.go
@@ -43,6 +43,8 @@ func provideCredentials(in credsIn) (*credentials.Credentials, error) {
 
 	opts := []credentials.Option{
 		credentials.URL(in.Creds.URL),
+		// enabling `Required` allows the xmidt-agent to send connect events for auth related errors
+		credentials.Required(),
 		credentials.HTTPClient(client),
 		credentials.MacAddress(in.ID.DeviceID),
 		credentials.SerialNumber(in.ID.SerialNumber),

--- a/internal/websocket/e2e_test.go
+++ b/internal/websocket/e2e_test.go
@@ -92,7 +92,6 @@ func TestEndToEnd(t *testing.T) {
 			Jitter:      1.0 / 3.0,
 			MaxInterval: 341*time.Second + 333*time.Millisecond,
 		}),
-		ws.WithIPv6(),
 		ws.WithIPv4(),
 		ws.NowFunc(time.Now),
 		ws.ConnectTimeout(30*time.Second),
@@ -110,7 +109,7 @@ func TestEndToEnd(t *testing.T) {
 	// Allow multiple calls to start.
 	got.Start()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2000*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 	defer cancel()
 
 	for {

--- a/internal/websocket/e2e_test.go
+++ b/internal/websocket/e2e_test.go
@@ -5,6 +5,7 @@ package websocket_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -59,7 +60,9 @@ func (ts *EndToEndTestSuite) TestEndToEnd() {
 
 				mt, got, err := c.Read(ctx)
 				// server will halt until the websocket closes resulting in a EOF
-				if ts.finished {
+				var closeErr websocket.CloseError
+				if ts.finished && errors.As(err, &closeErr) {
+					assert.Equal(closeErr.Code, websocket.StatusNormalClosure)
 					return
 				}
 

--- a/internal/websocket/ws_test.go
+++ b/internal/websocket/ws_test.go
@@ -366,9 +366,10 @@ func TestNextMode(t *testing.T) {
 				URL("http://example.com"),
 			)
 			got, err := New(opts...)
+			got.mode = tc.mode
 			require.NoError(err)
 			require.NotNil(got)
-			assert.Equal(tc.expected, got.nextMode(tc.mode))
+			assert.Equal(tc.expected, got.nextMode())
 		})
 	}
 }


### PR DESCRIPTION
Doesn't include `func (ws *websocket) Send()` update