### PR TITLE
feat: on dev mode log wrphandler errors

### DIFF
--- a/cmd/xmidt-agent/wrphandlers.go
+++ b/cmd/xmidt-agent/wrphandlers.go
@@ -49,7 +49,7 @@ func provideWSEventorToHandlerAdapter(in wsAdapterIn) {
 		event.MsgListenerFunc(func(m wrp.Message) {
 			err := in.AuthHandler.HandleWrp(m)
 			if in.CLI.Dev {
-				logger.Info("message listener", zap.Any("msg", m), zap.Error(err))
+				logger.Error("message listener", zap.Any("msg", m), zap.Error(err))
 			}
 		}),
 		&in.WRPHandlerAdapterCancel,


### PR DESCRIPTION
wrphandlers currently fail silently in the following situations:

- `msg.Type.RequiresTransaction` is false
- `msg.Type.RequiresTransaction` is true but the websocket/Egress fails