### PR TITLE
patch: fix network interface fx injection

### DIFF
--- a/cmd/xmidt-agent/main.go
+++ b/cmd/xmidt-agent/main.go
@@ -95,7 +95,7 @@ func xmidtAgent(args []string) (*fx.App, error) {
 			goschtalt.UnmarshalFunc[MockTr181]("mock_tr_181"),
 			goschtalt.UnmarshalFunc[Pubsub]("pubsub"),
 
-			NetworkServiceModule,
+			provideNetworkService,
 		),
 
 		fsProvide(),

--- a/cmd/xmidt-agent/network_service.go
+++ b/cmd/xmidt-agent/network_service.go
@@ -5,23 +5,8 @@ package main
 
 import (
 	"github.com/xmidt-org/xmidt-agent/internal/net"
-	"go.uber.org/fx"
 )
 
-type NetworkServiceIn struct {
-	fx.In
+func provideNetworkService() net.NetworkInterface {
+	return net.NewNetworkWrapper()
 }
-
-type NetworkServiceOut struct {
-	fx.Out
-	NetworkService *net.NetworkService
-}
-
-var NetworkServiceModule = fx.Module("networkService",
-	fx.Provide(
-		func(in NetworkServiceIn) *net.NetworkService {
-			return &net.NetworkService{
-				N: net.NewNetworkWrapper(),
-			}
-		}),
-)


### PR DESCRIPTION
can't start because of the following
```console
fx.Option should be passed to fx.New directly, not to fx.Provide: fx.Provide received fx.Module("networkService", [fx.Provide(main.glob..func1())]) from:
main.xmidtAgent
	/Users/odc/Documents/GitHub/xmidt-org/xmidt-agent/cmd/xmidt-agent/main.go:83
main.main
	/Users/odc/Documents/GitHub/xmidt-org/xmidt-agent/cmd/xmidt-agent/main.go:124
runtime.main
	/Users/odc/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.21.8.darwin-amd64/src/runtime/proc.go:267
```

this fixes the issue and makes the fx injection for the network-interface component consistent to the rest of the repo