### PR TITLE
tweak injection of identity

### DIFF
--- a/cmd/xmidt-agent/wrphandlers.go
+++ b/cmd/xmidt-agent/wrphandlers.go
@@ -54,7 +54,7 @@ type missingIn struct {
 
 	// Configuration
 	// Note, DeviceID and PartnerID is pulled from the Identity configuration
-	DeviceID wrp.DeviceID
+	Identity Identity
 
 	// wrphandlers
 	Egress websocket.Egress
@@ -62,7 +62,7 @@ type missingIn struct {
 }
 
 func provideMissingHandler(in missingIn) (*missing.Handler, error) {
-	h, err := missing.New(in.Pubsub, in.Egress, string(in.DeviceID))
+	h, err := missing.New(in.Pubsub, in.Egress, string(in.Identity.DeviceID))
 	if err != nil {
 		err = errors.Join(ErrWRPHandlerConfig, err)
 	}
@@ -75,8 +75,7 @@ type authIn struct {
 
 	// Configuration
 	// Note, DeviceID and PartnerID is pulled from the Identity configuration
-	DeviceID  wrp.DeviceID
-	PartnerID string
+	Identity Identity
 
 	// wrphandlers
 
@@ -85,7 +84,7 @@ type authIn struct {
 }
 
 func provideAuthHandler(in authIn) (*auth.Handler, error) {
-	h, err := auth.New(in.MissingHandler, in.Egress, string(in.DeviceID), in.PartnerID)
+	h, err := auth.New(in.MissingHandler, in.Egress, string(in.Identity.DeviceID), in.Identity.PartnerID)
 	if err != nil {
 		err = errors.Join(ErrWRPHandlerConfig, err)
 	}
@@ -98,7 +97,7 @@ type pubsubIn struct {
 
 	// Configuration
 	// Note, DeviceID and PartnerID is pulled from the Identity configuration
-	DeviceID  wrp.DeviceID
+	Identity  Identity
 	Pubsub    Pubsub
 	MockTr181 MockTr181
 
@@ -125,7 +124,7 @@ func providePubSubHandler(in pubsubIn) (pubsubOut, error) {
 	}
 
 	ps, err := pubsub.New(
-		in.DeviceID,
+		in.Identity.DeviceID,
 		opts...,
 	)
 	if err != nil {
@@ -137,7 +136,7 @@ func providePubSubHandler(in pubsubIn) (pubsubOut, error) {
 			mocktr181.FilePath(in.MockTr181.FilePath),
 			mocktr181.Enabled(in.MockTr181.Enabled),
 		}
-		mocktr181Handler, err := mocktr181.New(ps, string(in.DeviceID), mockDefaults...)
+		mocktr181Handler, err := mocktr181.New(ps, string(in.Identity.DeviceID), mockDefaults...)
 		if err != nil {
 			return pubsubOut{}, errors.Join(ErrWRPHandlerConfig, err)
 		}

--- a/cmd/xmidt-agent/ws.go
+++ b/cmd/xmidt-agent/ws.go
@@ -26,7 +26,7 @@ var (
 type wsIn struct {
 	fx.In
 	// Note, DeviceID is pulled from the Identity configuration
-	DeviceID  wrp.DeviceID
+	Identity  Identity
 	Logger    *zap.Logger
 	CLI       *CLI
 	JWTXT     *jwtxt.Instructions
@@ -50,7 +50,7 @@ func provideWS(in wsIn) (wsOut, error) {
 
 	// Configuration options
 	opts := []websocket.Option{
-		websocket.DeviceID(in.DeviceID),
+		websocket.DeviceID(in.Identity.DeviceID),
 		websocket.FetchURLTimeout(in.Websocket.FetchURLTimeout),
 		websocket.FetchURL(
 			fetchURL(in.Websocket.URLPath, in.Websocket.BackUpURL,


### PR DESCRIPTION
partnerId and DeviceID kept failing injection for me.  I'm not sure why just me, but relying on type makes it so that partnerId injection at the very least will have to change when another string is added. 