### PR TITLE
feat: implement configurable ping timeout for `nhooyr.io/websocket`

### DIFF
--- a/internal/nhooyr.io/websocket/close.go
+++ b/internal/nhooyr.io/websocket/close.go
@@ -156,6 +156,7 @@ func (c *Conn) writeClose(code StatusCode, reason string) error {
 	if ce.Code != StatusNoStatusRcvd {
 		p, marshalErr = ce.bytes()
 	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 

--- a/internal/nhooyr.io/websocket/close.go
+++ b/internal/nhooyr.io/websocket/close.go
@@ -156,8 +156,10 @@ func (c *Conn) writeClose(code StatusCode, reason string) error {
 	if ce.Code != StatusNoStatusRcvd {
 		p, marshalErr = ce.bytes()
 	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
 
-	writeErr := c.writeControl(context.Background(), opClose, p)
+	writeErr := c.writeControl(ctx, opClose, p)
 	if CloseStatus(writeErr) != -1 {
 		// Not a real error if it's due to a close frame being received.
 		writeErr = nil

--- a/internal/nhooyr.io/websocket/conn.go
+++ b/internal/nhooyr.io/websocket/conn.go
@@ -17,6 +17,7 @@ import (
 	"strconv"
 	"sync"
 	"sync/atomic"
+	"time"
 )
 
 // MessageType represents the type of a WebSocket message.
@@ -79,6 +80,7 @@ type Conn struct {
 	closeErr   error
 	wroteClose bool
 
+	pingTimeout   time.Duration
 	pingCounter   int32
 	activePingsMu sync.Mutex
 	activePings   map[string]chan<- struct{}

--- a/internal/nhooyr.io/websocket/write.go
+++ b/internal/nhooyr.io/websocket/write.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"time"
 
 	"compress/flate"
 
@@ -235,16 +234,6 @@ func (mw *msgWriter) close() {
 }
 
 func (c *Conn) writeControl(ctx context.Context, opcode opcode, p []byte) error {
-	ctx, cancel := context.WithTimeout(ctx, time.Second*5)
-	switch opcode {
-	case opPong:
-		if c.pingTimeout > 0 {
-			ctx, cancel = context.WithTimeout(ctx, c.pingTimeout)
-		}
-	}
-
-	defer cancel()
-
 	_, err := c.writeFrame(ctx, true, false, opcode, p)
 	if err != nil {
 		return fmt.Errorf("failed to write control frame %v: %w", opcode, err)

--- a/internal/nhooyr.io/websocket/write.go
+++ b/internal/nhooyr.io/websocket/write.go
@@ -236,6 +236,13 @@ func (mw *msgWriter) close() {
 
 func (c *Conn) writeControl(ctx context.Context, opcode opcode, p []byte) error {
 	ctx, cancel := context.WithTimeout(ctx, time.Second*5)
+	switch opcode {
+	case opPong:
+		if c.pingTimeout > 0 {
+			ctx, cancel = context.WithTimeout(ctx, c.pingTimeout)
+		}
+	}
+
 	defer cancel()
 
 	_, err := c.writeFrame(ctx, true, false, opcode, p)

--- a/internal/websocket/e2e_test.go
+++ b/internal/websocket/e2e_test.go
@@ -432,7 +432,7 @@ func TestEndToEndPingTimeout(t *testing.T) {
 	// All disconnectErrs errors should be caused by context.DeadlineExceeded
 	for _, err := range disconnectErrs {
 		if errors.Is(err, net.ErrClosed) {
-			// net.ErrClosed may occur during testing, don't count them
+			// net.ErrClosed may occur during tests, don't count them
 			continue
 		}
 

--- a/internal/websocket/e2e_test.go
+++ b/internal/websocket/e2e_test.go
@@ -427,7 +427,6 @@ func TestEndToEndPingTimeout(t *testing.T) {
 	assert.Equal(int64(0), heartbeatCnt.Load())
 	assert.Greater(connectCnt.Load(), int64(0))
 	assert.Greater(disconnectCnt.Load(), int64(0))
-	// disconnectErrs should only contain
 	assert.NotEmpty(disconnectErrs)
 	// disconnectErrs should only contain context.DeadlineExceeded errors
 	for _, err := range disconnectErrs {

--- a/internal/websocket/e2e_test.go
+++ b/internal/websocket/e2e_test.go
@@ -426,6 +426,9 @@ func TestEndToEndPingTimeout(t *testing.T) {
 		ws.CredentialsDecorator(func(h http.Header) error {
 			return nil
 		}),
+		ws.ConveyDecorator(func(h http.Header) error {
+			return nil
+		}),
 		// Triggers ping timeouts
 		ws.PingTimeout(time.Nanosecond),
 	)

--- a/internal/websocket/e2e_test.go
+++ b/internal/websocket/e2e_test.go
@@ -423,7 +423,7 @@ func TestEndToEndPingTimeout(t *testing.T) {
 	got.Start()
 	time.Sleep(500 * time.Millisecond)
 	got.Stop()
-	// heartbeatCnt should be zero due to a ping timeout
+	// heartbeatCnt should be zero due ping timeouts
 	assert.Equal(int64(0), heartbeatCnt.Load())
 	assert.Greater(connectCnt.Load(), int64(0))
 	assert.Greater(disconnectCnt.Load(), int64(0))

--- a/internal/websocket/e2e_test.go
+++ b/internal/websocket/e2e_test.go
@@ -420,7 +420,6 @@ func TestEndToEndPingTimeout(t *testing.T) {
 		}),
 		ws.WithIPv4(),
 		ws.NowFunc(time.Now),
-		ws.ConnectTimeout(30*time.Second),
 		ws.FetchURLTimeout(30*time.Second),
 		ws.MaxMessageBytes(256*1024),
 		ws.CredentialsDecorator(func(h http.Header) error {
@@ -431,6 +430,7 @@ func TestEndToEndPingTimeout(t *testing.T) {
 		}),
 		// Triggers ping timeouts
 		ws.PingTimeout(time.Nanosecond),
+		ws.HTTPClient(nil),
 	)
 	require.NoError(err)
 	require.NotNil(got)

--- a/internal/websocket/e2e_test.go
+++ b/internal/websocket/e2e_test.go
@@ -414,7 +414,7 @@ func TestEndToEndPingTimeout(t *testing.T) {
 		ws.CredentialsDecorator(func(h http.Header) error {
 			return nil
 		}),
-		// Trigger a ping timeout
+		// Triggers ping timeouts
 		ws.PingTimeout(time.Nanosecond),
 	)
 	require.NoError(err)

--- a/internal/websocket/e2e_test.go
+++ b/internal/websocket/e2e_test.go
@@ -429,7 +429,7 @@ func TestEndToEndPingTimeout(t *testing.T) {
 	assert.Greater(disconnectCnt.Load(), int64(0))
 	// disconnectErrs should only contain
 	assert.NotEmpty(disconnectErrs)
-	// All disconnectErrs errors should be caused by context.DeadlineExceeded
+	// disconnectErrs should only contain context.DeadlineExceeded errors
 	for _, err := range disconnectErrs {
 		if errors.Is(err, net.ErrClosed) {
 			// net.ErrClosed may occur during tests, don't count them

--- a/internal/websocket/ws.go
+++ b/internal/websocket/ws.go
@@ -233,7 +233,11 @@ func (ws *Websocket) run(ctx context.Context) {
 			// Store the connection so writing can take place.
 			ws.m.Lock()
 			ws.conn = conn
-			ws.conn.SetPingListener((func(context.Context, []byte) {
+			ws.conn.SetPingListener((func(ctx context.Context, b []byte) {
+				if ctx.Err() != nil {
+					return
+				}
+
 				ws.heartbeatListeners.Visit(func(l event.HeartbeatListener) {
 					l.OnHeartbeat(event.Heartbeat{
 						At:   ws.nowFunc(),
@@ -242,6 +246,10 @@ func (ws *Websocket) run(ctx context.Context) {
 				})
 			}))
 			ws.conn.SetPongListener(func(ctx context.Context, b []byte) {
+				if ctx.Err() != nil {
+					return
+				}
+
 				ws.heartbeatListeners.Visit(func(l event.HeartbeatListener) {
 					l.OnHeartbeat(event.Heartbeat{
 						At:   ws.nowFunc(),
@@ -334,6 +342,7 @@ func (ws *Websocket) dial(ctx context.Context, mode ipMode) (*nhws.Conn, *http.R
 	}
 
 	conn.SetReadLimit(ws.maxMessageBytes)
+	conn.SetPingTimeout(ws.pingTimeout)
 	return conn, resp, nil
 }
 


### PR DESCRIPTION
implements #83 #88

- Add configurable `pingTimeout` to `internal/nhooyr.io/websocket/conn.go`'s `Conn struct`.
- Implement timeouts for pings.
- Add ping/pong listeners support for context timeout/cancel 