### PR TITLE
add stub for setting and retrieving interface-used from the websocket

### DIFF
--- a/cmd/xmidt-agent/config.go
+++ b/cmd/xmidt-agent/config.go
@@ -22,6 +22,7 @@ import (
 	"github.com/xmidt-org/sallust"
 	"github.com/xmidt-org/wrp-go/v3"
 	"github.com/xmidt-org/xmidt-agent/internal/configuration"
+	"github.com/xmidt-org/xmidt-agent/internal/net"
 	"go.uber.org/zap/zapcore"
 	"gopkg.in/dealancer/validate.v2"
 )
@@ -220,7 +221,7 @@ type Metadata struct {
 
 type NetworkService struct {
 	// list of allowed network interfaces to connect to xmidt in priority order, first is highest
-	AllowedInterfaces []string
+	AllowedInterfaces map[string]net.AllowedInterface
 }
 
 // Collect and process the configuration files and env vars and
@@ -404,6 +405,6 @@ var defaultConfig = Config{
 		Fields: []string{"fw-name", "hw-model", "hw-manufacturer", "hw-serial-number", "hw-last-reboot-reason", "webpa-protocol", "boot-time", "boot-time-retry-wait", "webpa-interface-used", "interfaces-available"},
 	},
 	NetworkService: NetworkService{
-		AllowedInterfaces: []string{"erouter0", "eroutev0", "br-home", "brrwan", "vdsl0", "wwan0", "wlan0", "eth0", "qmapmux0.127", "cm0"},
+		AllowedInterfaces: map[string]net.AllowedInterface{"erouter0": {Priority: 1, Enabled: true}, "eroutev0": {Priority: 2, Enabled: true}, "br-home": {Priority: 3, Enabled: true}, "brrwan": {Priority: 4, Enabled: true}, "vdsl0": {Priority: 5, Enabled: true}, "wwan0": {Priority: 6, Enabled: true}, "wlan0": {Priority: 7, Enabled: true}, "eth0": {Priority: 8, Enabled: true}, "qmapmux0.127": {Priority: 9, Enabled: true}, "cm0": {Priority: 10, Enabled: true}},
 	},
 }

--- a/cmd/xmidt-agent/config.go
+++ b/cmd/xmidt-agent/config.go
@@ -41,6 +41,7 @@ type Config struct {
 	Externals        []configuration.External
 	XmidtAgentCrud   XmidtAgentCrud
 	Metadata         Metadata
+	NetworkService   NetworkService
 }
 
 type QOS struct {
@@ -215,6 +216,10 @@ type MockTr181 struct {
 
 type Metadata struct {
 	Fields []string
+}
+
+type NetworkService struct {
+	AllowedInterfaces []string
 }
 
 // Collect and process the configuration files and env vars and
@@ -396,5 +401,8 @@ var defaultConfig = Config{
 	},
 	Metadata: Metadata{
 		Fields: []string{"fw-name", "hw-model", "hw-manufacturer", "hw-serial-number", "hw-last-reboot-reason", "webpa-protocol", "boot-time", "boot-time-retry-wait", "webpa-interface-used", "interfaces-available"},
+	},
+	NetworkService: NetworkService{
+		AllowedInterfaces: []string{"erouter0", "eroutev0", "br-home", "brrwan", "vdsl0", "wwan0", "wlan0", "eth0", "qmapmux0.127", "cm0"},
 	},
 }

--- a/cmd/xmidt-agent/config.go
+++ b/cmd/xmidt-agent/config.go
@@ -219,6 +219,7 @@ type Metadata struct {
 }
 
 type NetworkService struct {
+	// list of allowed network interfaces to connect to xmidt in priority order, first is highest
 	AllowedInterfaces []string
 }
 

--- a/cmd/xmidt-agent/main.go
+++ b/cmd/xmidt-agent/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/xmidt-org/sallust"
 	"github.com/xmidt-org/xmidt-agent/internal/credentials"
 	"github.com/xmidt-org/xmidt-agent/internal/loglevel"
+	"github.com/xmidt-org/xmidt-agent/internal/metadata"
 	"github.com/xmidt-org/xmidt-agent/internal/pubsub"
 	"github.com/xmidt-org/xmidt-agent/internal/websocket"
 	"github.com/xmidt-org/xmidt-agent/internal/websocket/event"
@@ -103,6 +104,7 @@ func xmidtAgent(args []string) (*fx.App, error) {
 			provideNetworkService,
 			provideMetadataProvider,
 			loglevel.New,
+			metadata.NewInterfaceUsedProvider,
 		),
 
 		fsProvide(),

--- a/cmd/xmidt-agent/main.go
+++ b/cmd/xmidt-agent/main.go
@@ -96,6 +96,7 @@ func xmidtAgent(args []string) (*fx.App, error) {
 			goschtalt.UnmarshalFunc[MockTr181]("mock_tr_181"),
 			goschtalt.UnmarshalFunc[Pubsub]("pubsub"),
 			goschtalt.UnmarshalFunc[Metadata]("metadata"),
+			goschtalt.UnmarshalFunc[NetworkService]("network_service"),
 			goschtalt.UnmarshalFunc[QOS]("qos"),
 
 			provideNetworkService,

--- a/cmd/xmidt-agent/metadata.go
+++ b/cmd/xmidt-agent/metadata.go
@@ -18,6 +18,7 @@ type metadataIn struct {
 	ID             Identity
 	Ops            OperationalState
 	Metadata       Metadata
+	InterfaceUsed  *metadata.InterfaceUsedProvider
 }
 
 func provideMetadataProvider(in metadataIn) (*metadata.MetadataProvider, error) {
@@ -32,6 +33,7 @@ func provideMetadataProvider(in metadataIn) (*metadata.MetadataProvider, error) 
 		metadata.XmidtProtocolOpt(xmidtProtocol),
 		metadata.BootTimeOpt(in.Ops.BootTime.String()),
 		metadata.BootRetryWaitOpt(time.Second), // should this be configured?
+		metadata.InterfaceUsedOpt(in.InterfaceUsed),
 	}
 	return metadata.New(opts...)
 }

--- a/cmd/xmidt-agent/network_service.go
+++ b/cmd/xmidt-agent/network_service.go
@@ -5,10 +5,14 @@ package main
 
 import (
 	"github.com/xmidt-org/xmidt-agent/internal/net"
+	"go.uber.org/fx"
 )
 
-func provideNetworkService() net.NetworkServicer {
-	return &net.NetworkService{
-		N: net.NewNetworkWrapper(),
-	}
+type networkServiceIn struct {
+	fx.In
+	NetworkService NetworkService
+}
+
+func provideNetworkService(in networkServiceIn) net.NetworkServicer {
+	return net.New(net.NewNetworkWrapper(), in.NetworkService.AllowedInterfaces)
 }

--- a/cmd/xmidt-agent/ws.go
+++ b/cmd/xmidt-agent/ws.go
@@ -26,13 +26,14 @@ var (
 type wsIn struct {
 	fx.In
 	// Note, DeviceID is pulled from the Identity configuration
-	Identity  Identity
-	Logger    *zap.Logger
-	CLI       *CLI
-	JWTXT     *jwtxt.Instructions
-	Cred      *credentials.Credentials
-	Metadata  *metadata.MetadataProvider
-	Websocket Websocket
+	Identity      Identity
+	Logger        *zap.Logger
+	CLI           *CLI
+	JWTXT         *jwtxt.Instructions
+	Cred          *credentials.Credentials
+	Metadata      *metadata.MetadataProvider
+	InterfaceUsed *metadata.InterfaceUsedProvider
+	Websocket     Websocket
 }
 
 type wsOut struct {
@@ -79,6 +80,7 @@ func provideWS(in wsIn) (wsOut, error) {
 		websocket.WithIPv4(!in.Websocket.DisableV4),
 		websocket.Once(in.Websocket.Once),
 		websocket.RetryPolicy(in.Websocket.RetryPolicy),
+		websocket.InterfaceUsedProvider(in.InterfaceUsed),
 	}
 
 	// Listener options

--- a/cmd/xmidt-agent/ws.go
+++ b/cmd/xmidt-agent/ws.go
@@ -93,7 +93,6 @@ func provideWS(in wsIn) (wsOut, error) {
 		websocket.InterfaceUsedProvider(in.InterfaceUsed),
 	)
 
-
 	// Listener options
 	var (
 		msg, con, discon, heartbeat event.CancelFunc

--- a/internal/metadata/interface_used.go
+++ b/internal/metadata/interface_used.go
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2024 Comcast Cable Communications Management, LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package metadata
+
+const DefaultInterface = "erouter0"
+
+type InterfaceUsedProvider struct {
+	interfaceUsed string
+}
+
+func NewInterfaceUsedProvider() (*InterfaceUsedProvider, error) {
+	return &InterfaceUsedProvider{
+		interfaceUsed: DefaultInterface,
+	}, nil
+}
+
+func (i *InterfaceUsedProvider) GetInterfaceUsed() string {
+	return i.interfaceUsed
+}
+
+func (i *InterfaceUsedProvider) SetInterfaceUsed(interfaceUsed string) {
+	i.interfaceUsed = interfaceUsed
+}

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -51,6 +51,7 @@ type MetadataProvider struct {
 	protocol           string
 	bootTime           string
 	bootTimeRetryDelay string
+	interfaceUsed      *InterfaceUsedProvider
 }
 
 func New(opts ...Option) (*MetadataProvider, error) {
@@ -88,10 +89,12 @@ func (c *MetadataProvider) GetMetadata() map[string]interface{} {
 			header[field] = c.bootTime
 		case BootTimeRetryDelay:
 			header[field] = c.bootTimeRetryDelay
+		case InterfaceUsed:
+			header[field] = c.interfaceUsed.GetInterfaceUsed()
 		case InterfacesAvailable: // what if we can't get interfaces available?
 			names, err := c.networkService.GetInterfaceNames()
 			if err != nil {
-				// The err itself is ignored.
+				// The err itself is ignored. Log this somewhere tho
 				continue
 			}
 			header[field] = strings.Join(names, ",")

--- a/internal/metadata/options.go
+++ b/internal/metadata/options.go
@@ -109,3 +109,14 @@ func BootRetryWaitOpt(bootTimeRetryDelay time.Duration) Option {
 			return nil
 		})
 }
+
+func InterfaceUsedOpt(interfaceUsed *InterfaceUsedProvider) Option {
+	return optionFunc(
+		func(c *MetadataProvider) error {
+			if interfaceUsed == nil {
+				return fmt.Errorf("%w: nil interfaceUsed provider", ErrInvalidInput)
+			}
+			c.interfaceUsed = interfaceUsed
+			return nil
+		})
+}

--- a/internal/net/network_service.go
+++ b/internal/net/network_service.go
@@ -16,10 +16,15 @@ type NetworkServicer interface {
 
 type NetworkService struct {
 	N                 NetworkWrapper
-	AllowedInterfaces []string // should be supplied in priority order
+	AllowedInterfaces map[string]AllowedInterface
 }
 
-func New(n NetworkWrapper, allowedInterfaces []string) NetworkServicer {
+type AllowedInterface struct {
+	Priority int
+	Enabled  bool
+}
+
+func New(n NetworkWrapper, allowedInterfaces map[string]AllowedInterface) NetworkServicer {
 	return &NetworkService{
 		N:                 n,
 		AllowedInterfaces: allowedInterfaces,
@@ -62,9 +67,13 @@ func (ns *NetworkService) GetInterfaceNames() ([]string, error) {
 }
 
 func (ns *NetworkService) isAllowed(name string) bool {
-	for _, n := range ns.AllowedInterfaces {
-		if strings.EqualFold(name, n) {
-			return true
+	for k, v := range ns.AllowedInterfaces {
+		if strings.EqualFold(name, k) {
+			if v.Enabled {
+				return true
+			} else {
+				return false
+			}
 		}
 	}
 
@@ -72,11 +81,11 @@ func (ns *NetworkService) isAllowed(name string) bool {
 }
 
 func (ns *NetworkService) getPriority(name string) int {
-	for i, n := range ns.AllowedInterfaces {
-		if strings.EqualFold(name, n) {
-			return i
+	for k, v := range ns.AllowedInterfaces {
+		if strings.EqualFold(name, k) {
+			return v.Priority
 		}
 	}
 
-	return 100 // this should never happen
+	return 100 // not found should never happen
 }

--- a/internal/net/network_service_test.go
+++ b/internal/net/network_service_test.go
@@ -40,6 +40,23 @@ func (suite *NetworkServiceSuite) SetupTest() {
 	suite.mockNetworkWrapper = mockNetworkWrapper
 }
 
+func (suite *NetworkServiceSuite) TestGetInterfaces() {
+	hwa, err := net.ParseMAC("11:22:33:44:55:66")
+	suite.NoError(err)
+	iface := net.Interface{
+		Name:         "erouter0",
+		HardwareAddr: hwa,
+		Flags:        32,
+	}
+
+	suite.mockNetworkWrapper.On("Interfaces").Return([]net.Interface{iface}, nil)
+	ifaces, err := suite.networkService.GetInterfaces()
+	suite.NoError(err)
+	suite.Equal(1, len(ifaces))
+	suite.Equal("erouter0", ifaces[0].Name)
+	suite.Equal("11:22:33:44:55:66", ifaces[0].HardwareAddr.String())
+}
+
 func (suite *NetworkServiceSuite) TestGetInterfaceNames() {
 	iface := net.Interface{
 		Name:  "erouter0",

--- a/internal/net/network_service_test.go
+++ b/internal/net/network_service_test.go
@@ -35,7 +35,8 @@ func TestNetworkServiceSuite(t *testing.T) {
 
 func (suite *NetworkServiceSuite) SetupTest() {
 	mockNetworkWrapper := newMockNetworkWrapper()
-	networkService := New(mockNetworkWrapper, []string{"erouter0", "eth0"})
+	networkService := New(mockNetworkWrapper, map[string]AllowedInterface{
+		"erouter0": {1, true}, "eth0": {2, true}, "br-home": {3, false}})
 	suite.networkService = networkService
 	suite.mockNetworkWrapper = mockNetworkWrapper
 }

--- a/internal/websocket/options.go
+++ b/internal/websocket/options.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/xmidt-org/retry"
 	"github.com/xmidt-org/wrp-go/v3"
+	"github.com/xmidt-org/xmidt-agent/internal/metadata"
 	"github.com/xmidt-org/xmidt-agent/internal/websocket/event"
 )
 
@@ -337,6 +338,18 @@ func AddHeartbeatListener(listener event.HeartbeatListener, cancel ...*event.Can
 			var ignored event.CancelFunc
 			cancel = append(cancel, &ignored)
 			*cancel[0] = event.CancelFunc(ws.heartbeatListeners.Add(listener))
+			return nil
+		})
+}
+
+func InterfaceUsedProvider(interfaceUsed *metadata.InterfaceUsedProvider) Option {
+	return optionFunc(
+		func(ws *Websocket) error {
+			if interfaceUsed == nil {
+				return fmt.Errorf("%w: nil InterfaceUsedProvider", ErrMisconfiguredWS)
+			}
+
+			ws.interfaceUsed = interfaceUsed
 			return nil
 		})
 }

--- a/internal/websocket/ws.go
+++ b/internal/websocket/ws.go
@@ -14,6 +14,7 @@ import (
 	"github.com/xmidt-org/eventor"
 	"github.com/xmidt-org/retry"
 	"github.com/xmidt-org/wrp-go/v3"
+	"github.com/xmidt-org/xmidt-agent/internal/metadata"
 	nhws "github.com/xmidt-org/xmidt-agent/internal/nhooyr.io/websocket"
 	"github.com/xmidt-org/xmidt-agent/internal/websocket/event"
 )
@@ -109,6 +110,8 @@ type Websocket struct {
 	shutdown context.CancelFunc
 
 	conn *nhws.Conn
+
+	interfaceUsed *metadata.InterfaceUsedProvider
 }
 
 // Option is a functional option type for WS.


### PR DESCRIPTION
The actual setting of interface used is not implemented here because it requires a custom net.Dialer which is still outstanding in a different commit. 

This just stubs out how to get the interface-used value from websocket to the metadata provider. 

**** Note that "allowedInterfaces" is configurable.  This seems shaky if network interface names change. ***
