### PR TITLE
feat: add a few sane websocket defaults

### DIFF
--- a/internal/websocket/ws.go
+++ b/internal/websocket/ws.go
@@ -113,9 +113,17 @@ func (f optionFunc) apply(c *Websocket) error {
 	return f(c)
 }
 
+func emptyDecorator(http.Header) error {
+	return nil
+}
+
 // New creates a new WS connection with the given options.
 func New(opts ...Option) (*Websocket, error) {
-	var ws Websocket
+	ws := Websocket{
+		credDecorator:   emptyDecorator,
+		conveyDecorator: emptyDecorator,
+		client:          &http.Client{},
+	}
 
 	opts = append(opts,
 		validateDeviceID(),

--- a/internal/websocket/ws_test.go
+++ b/internal/websocket/ws_test.go
@@ -428,3 +428,7 @@ func TestLimit(t *testing.T) {
 		})
 	}
 }
+
+func Test_emptyDecorator(t *testing.T) {
+	assert.NoError(t, emptyDecorator(http.Header{}))
+}


### PR DESCRIPTION
For testing and other cases it's nice to automatically have an empty *http.Client as well as empty decorators when they aren't definitely needed.