### PR TITLE
feat: support openfail by default

### DIFF
--- a/cmd/xmidt-agent/main.go
+++ b/cmd/xmidt-agent/main.go
@@ -226,7 +226,7 @@ func onStart(cred *credentials.Credentials, ws *websocket.Websocket, qos *qos.Ha
 			return nil
 		}
 
-		// in case of openfail, cred will be nil
+		// Agent will openfail if its config section `xmidt_credentials` is omitted (cred will be nil).
 		if cred != nil {
 			ctx, cancel := context.WithTimeout(ctx, waitUntilFetched)
 			defer cancel()

--- a/cmd/xmidt-agent/main.go
+++ b/cmd/xmidt-agent/main.go
@@ -226,7 +226,7 @@ func onStart(cred *credentials.Credentials, ws *websocket.Websocket, qos *qos.Ha
 			return nil
 		}
 
-		// Agent will openfail if its config section `xmidt_credentials` is omitted (cred will be nil).
+		// Allow operations where no credentials are desired (cred will be nil).
 		if cred != nil {
 			ctx, cancel := context.WithTimeout(ctx, waitUntilFetched)
 			defer cancel()

--- a/cmd/xmidt-agent/main.go
+++ b/cmd/xmidt-agent/main.go
@@ -226,10 +226,14 @@ func onStart(cred *credentials.Credentials, ws *websocket.Websocket, qos *qos.Ha
 			return nil
 		}
 
-		ctx, cancel := context.WithTimeout(ctx, waitUntilFetched)
-		defer cancel()
-		// blocks until an attempt to fetch the credentials has been made or the context is canceled
-		cred.WaitUntilFetched(ctx)
+		// in case of openfail, cred will be nil
+		if cred != nil {
+			ctx, cancel := context.WithTimeout(ctx, waitUntilFetched)
+			defer cancel()
+			// blocks until an attempt to fetch the credentials has been made or the context is canceled
+			cred.WaitUntilFetched(ctx)
+		}
+
 		ws.Start()
 		qos.Start()
 

--- a/cmd/xmidt-agent/ws.go
+++ b/cmd/xmidt-agent/ws.go
@@ -61,7 +61,7 @@ func provideWS(in wsIn) (wsOut, error) {
 
 	credDecorator := func(http.Header) error { return nil }
 	// Cred is not required
-	// credDecorator() will default to openfail if in.Cred is nil
+	// Agent will openfail if its config section `xmidt_credentials` is omitted (in.Cred will be nil).
 	if in.Cred != nil {
 		credDecorator = in.Cred.Decorate
 	}

--- a/cmd/xmidt-agent/ws.go
+++ b/cmd/xmidt-agent/ws.go
@@ -64,8 +64,7 @@ func provideWS(in wsIn) (wsOut, error) {
 	}
 
 	var opts []websocket.Option
-	// Cred is not required
-	// Agent will openfail if its config section `xmidt_credentials` is omitted (in.Cred will be nil).
+	// Allow operations where no credentials are desired (in.Cred will be nil).
 	if in.Cred != nil {
 		opts = append(opts, websocket.CredentialsDecorator(in.Cred.Decorate))
 	}

--- a/internal/websocket/ws.go
+++ b/internal/websocket/ws.go
@@ -225,7 +225,7 @@ func (ws *Websocket) run(ctx context.Context) {
 			Mode:    mode.ToEvent(),
 		}
 
-		// If auth fails, then continue with openfail xmidt connection
+		// If auth fails, then continue with no credentials.
 		ws.credDecorator(ws.additionalHeaders)
 
 		ws.conveyDecorator(ws.additionalHeaders)


### PR DESCRIPTION
implements openfail

- if the agent's config is missing the `xmidt_credentials`, then the agent will connect to xmidt via openfail