### PR TITLE
feat: refactor `providePubSubHandler`

### DIFF
--- a/cmd/xmidt-agent/wrphandlers.go
+++ b/cmd/xmidt-agent/wrphandlers.go
@@ -196,9 +196,6 @@ type mockTr181In struct {
 	MockTr181 MockTr181
 
 	PubSub *pubsub.PubSub
-
-	// wrphandlers
-	Egress *qos.Handler
 }
 
 type mockTr181Out struct {


### PR DESCRIPTION
- refactor `providePubSubHandler`, moving  mocktr181's setup to `provideMockTr181Handler`