### PR TITLE
refactor: Refactor pubsub package in order to keep defaults consistent

### DIFF
--- a/cmd/xmidt-agent/config.go
+++ b/cmd/xmidt-agent/config.go
@@ -362,7 +362,7 @@ var defaultConfig = Config{
 		},
 	},
 	Pubsub: Pubsub{
-		PublishTimeout: 200 * time.Millisecond,
+		PublishTimeout: 5 * time.Second,
 	},
 	Logger: sallust.Config{
 		EncoderConfig: sallust.EncoderConfig{

--- a/internal/adapters/libparodus/end2end_test.go
+++ b/internal/adapters/libparodus/end2end_test.go
@@ -124,7 +124,7 @@ func TestEnd2End(t *testing.T) {
 	require.NoError(err)
 	require.NotEmpty(self)
 
-	ps, err := pubsub.New(self)
+	ps, err := pubsub.New(self, pubsub.WithPublishTimeout(200*time.Millisecond))
 	require.NoError(err)
 	require.NotNil(ps)
 

--- a/internal/pubsub/end2end_test.go
+++ b/internal/pubsub/end2end_test.go
@@ -226,6 +226,7 @@ func TestEndToEnd(t *testing.T) {
 			wrp.EnsureTransactionUUID(),
 			wrp.ValidateOnlyUTF8Strings(),
 		),
+		pubsub.WithPublishTimeout(200*time.Millisecond),
 	)
 
 	require.NoError(err)

--- a/internal/pubsub/pubsub.go
+++ b/internal/pubsub/pubsub.go
@@ -69,13 +69,6 @@ func New(self wrp.DeviceID, opts ...Option) (*PubSub, error) {
 		),
 	}
 
-	defaults := []Option{
-		WithPublishTimeout(5 * time.Second),
-	}
-
-	// Prepend the defaults to the provided options.
-	opts = append(defaults, opts...)
-
 	for _, opt := range opts {
 		if opt != nil {
 			if err := opt.apply(&ps); err != nil {


### PR DESCRIPTION
- Refactor the pubsub package in order to keep defaults consistent, since defaults are set in `cmd/xmidt-agent/config.go`