### PR TITLE
refactor: Use websocket's default http client

### DIFF
--- a/internal/websocket/e2e_test.go
+++ b/internal/websocket/e2e_test.go
@@ -427,7 +427,6 @@ func TestEndToEndPingTimeout(t *testing.T) {
 		}),
 		// Triggers ping timeouts
 		ws.PingTimeout(time.Nanosecond),
-		ws.HTTPClient(nil),
 	)
 	require.NoError(err)
 	require.NotNil(got)

--- a/internal/websocket/e2e_test.go
+++ b/internal/websocket/e2e_test.go
@@ -106,7 +106,6 @@ func TestEndToEnd(t *testing.T) {
 		ws.ConveyDecorator(func(h http.Header) error {
 			return nil
 		}),
-		ws.HTTPClient(nil),
 	)
 	require.NoError(err)
 	require.NotNil(got)
@@ -233,7 +232,6 @@ func TestEndToEndBadData(t *testing.T) {
 				ws.ConveyDecorator(func(h http.Header) error {
 					return nil
 				}),
-				ws.HTTPClient(nil),
 			)
 			require.NoError(err)
 			require.NotNil(got)
@@ -330,7 +328,6 @@ func TestEndToEndConnectionIssues(t *testing.T) {
 		ws.ConveyDecorator(func(h http.Header) error {
 			return nil
 		}),
-		ws.HTTPClient(nil),
 	)
 	require.NoError(err)
 	require.NotNil(got)

--- a/internal/websocket/options.go
+++ b/internal/websocket/options.go
@@ -5,12 +5,10 @@ package websocket
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"time"
 
-	"github.com/xmidt-org/arrange/arrangehttp"
 	"github.com/xmidt-org/retry"
 	"github.com/xmidt-org/wrp-go/v3"
 	"github.com/xmidt-org/xmidt-agent/internal/metadata"
@@ -185,12 +183,7 @@ func HTTPClient(client *http.Client) Option {
 		func(ws *Websocket) error {
 			var err error
 			if client == nil {
-				// Can't use http.DefaultClient since its Transport is nil.
-				client, err = arrangehttp.ClientConfig{}.NewClient()
-			}
-
-			if err != nil {
-				return errors.Join(ErrMisconfiguredWS, err)
+				return ErrMisconfiguredWS
 			}
 
 			ws.client = client

--- a/internal/websocket/ws.go
+++ b/internal/websocket/ws.go
@@ -360,9 +360,14 @@ func (rt *custRT) RoundTrip(r *http.Request) (*http.Response, error) {
 // updateClientTransport updates the http client's Transport and set the DialContext's
 // named network as the provided `mode`.
 func (ws *Websocket) updateClientTransport(mode ipMode) {
+	// Check for nil Transports, e.g.: http.DefaultClient & http.Client{}.
+	transport, ok := ws.client.Transport.(*http.Transport)
+	if !ok {
+		transport = &http.Transport{}
+	}
+
 	// Override client's Transport with custRT (reusing certain configurations)
 	// and update it's DialContext with the provided mode.
-	transport := ws.client.Transport.(*http.Transport)
 	ws.client.Transport = &custRT{
 		transport: http.Transport{
 			Proxy:                 http.ProxyFromEnvironment,

--- a/internal/websocket/ws.go
+++ b/internal/websocket/ws.go
@@ -369,14 +369,9 @@ func (rt *custRT) RoundTrip(r *http.Request) (*http.Response, error) {
 // updateClientTransport updates the http client's Transport and set the DialContext's
 // named network as the provided `mode`.
 func (ws *Websocket) updateClientTransport(mode ipMode) {
-	// Check for nil Transports, e.g.: http.DefaultClient & http.Client{}.
-	transport, ok := ws.client.Transport.(*http.Transport)
-	if !ok {
-		transport = &http.Transport{}
-	}
-
 	// Override client's Transport with custRT (reusing certain configurations)
 	// and update it's DialContext with the provided mode.
+	transport := ws.client.Transport.(*http.Transport)
 	ws.client.Transport = &custRT{
 		transport: http.Transport{
 			Proxy:                 http.ProxyFromEnvironment,

--- a/internal/websocket/ws_test.go
+++ b/internal/websocket/ws_test.go
@@ -29,7 +29,6 @@ func TestNew(t *testing.T) {
 
 	wsDefaults := []Option{
 		WithIPv6(),
-		HTTPClient(nil),
 	}
 	tests := []struct {
 		description string
@@ -61,7 +60,6 @@ func TestNew(t *testing.T) {
 				}),
 				NowFunc(time.Now),
 				RetryPolicy(retry.Config{}),
-				HTTPClient(nil),
 			),
 			check: func(assert *assert.Assertions, c *Websocket) {
 				// URL Related
@@ -103,7 +101,6 @@ func TestNew(t *testing.T) {
 				}),
 				NowFunc(time.Now),
 				RetryPolicy(retry.Config{}),
-				HTTPClient(nil),
 			),
 			check: func(assert *assert.Assertions, c *Websocket) {
 				u, err := c.urlFetcher(context.Background())
@@ -143,6 +140,12 @@ func TestNew(t *testing.T) {
 				PingTimeout(-1),
 			},
 			expectedErr: ErrMisconfiguredWS,
+		}, {
+			description: "nil http client",
+			opts: []Option{
+				HTTPClient(nil),
+			},
+			expectedErr: ErrMisconfiguredWS,
 		},
 
 		// Test the now func option
@@ -162,7 +165,6 @@ func TestNew(t *testing.T) {
 					return nil
 				}),
 				RetryPolicy(retry.Config{}),
-				HTTPClient(nil),
 			),
 			check: func(assert *assert.Assertions, c *Websocket) {
 				if assert.NotNil(c.nowFunc) {
@@ -226,7 +228,6 @@ func TestMessageListener(t *testing.T) {
 		}),
 		NowFunc(time.Now),
 		RetryPolicy(retry.Config{}),
-		HTTPClient(nil),
 	)
 
 	assert.NoError(err)
@@ -258,7 +259,6 @@ func TestConnectListener(t *testing.T) {
 		}),
 		NowFunc(time.Now),
 		RetryPolicy(retry.Config{}),
-		HTTPClient(nil),
 	)
 
 	assert.NoError(err)
@@ -290,7 +290,6 @@ func TestDisconnectListener(t *testing.T) {
 		}),
 		NowFunc(time.Now),
 		RetryPolicy(retry.Config{}),
-		HTTPClient(nil),
 	)
 
 	assert.NoError(err)
@@ -322,7 +321,6 @@ func TestHeartbeatListener(t *testing.T) {
 		}),
 		NowFunc(time.Now),
 		RetryPolicy(retry.Config{}),
-		HTTPClient(nil),
 	)
 
 	assert.NoError(err)
@@ -344,7 +342,6 @@ func TestNextMode(t *testing.T) {
 		}),
 		NowFunc(time.Now),
 		RetryPolicy(retry.Config{}),
-		HTTPClient(nil),
 	}
 	tests := []struct {
 		description string


### PR DESCRIPTION
- Use websocket's default http client by default.
- A nil http client option will error out.
- Update related tests..