### PR TITLE
revert: undo how websocket's http client is configured and reused

### DIFF
--- a/cmd/xmidt-agent/ws.go
+++ b/cmd/xmidt-agent/ws.go
@@ -59,11 +59,6 @@ func provideWS(in wsIn) (wsOut, error) {
 		fetchURLFunc = in.JWTXT.Endpoint
 	}
 
-	client, err := in.Websocket.HTTPClient.NewClient()
-	if err != nil {
-		return wsOut{}, err
-	}
-
 	var opts []websocket.Option
 	// Allow operations where no credentials are desired (in.Cred will be nil).
 	if in.Cred != nil {
@@ -81,7 +76,7 @@ func provideWS(in wsIn) (wsOut, error) {
 		websocket.PingTimeout(in.Websocket.PingTimeout),
 		websocket.SendTimeout(in.Websocket.SendTimeout),
 		websocket.KeepAliveInterval(in.Websocket.KeepAliveInterval),
-		websocket.HTTPClient(client),
+		websocket.HTTPClientWithForceSets(in.Websocket.HTTPClient),
 		websocket.MaxMessageBytes(in.Websocket.MaxMessageBytes),
 		websocket.ConveyDecorator(in.Metadata.Decorate),
 		websocket.AdditionalHeaders(in.Websocket.AdditionalHeaders),

--- a/internal/websocket/e2e_test.go
+++ b/internal/websocket/e2e_test.go
@@ -107,7 +107,6 @@ func TestEndToEnd(t *testing.T) {
 		ws.ConveyDecorator(func(h http.Header) error {
 			return nil
 		}),
-		ws.HTTPClient(nil),
 	)
 	require.NoError(err)
 	require.NotNil(got)
@@ -234,7 +233,6 @@ func TestEndToEndBadData(t *testing.T) {
 				ws.ConveyDecorator(func(h http.Header) error {
 					return nil
 				}),
-				ws.HTTPClient(nil),
 			)
 			require.NoError(err)
 			require.NotNil(got)
@@ -331,7 +329,6 @@ func TestEndToEndConnectionIssues(t *testing.T) {
 		ws.ConveyDecorator(func(h http.Header) error {
 			return nil
 		}),
-		ws.HTTPClient(nil),
 	)
 	require.NoError(err)
 	require.NotNil(got)
@@ -430,7 +427,6 @@ func TestEndToEndPingTimeout(t *testing.T) {
 		}),
 		// Triggers ping timeouts
 		ws.PingTimeout(time.Nanosecond),
-		ws.HTTPClient(nil),
 	)
 	require.NoError(err)
 	require.NotNil(got)

--- a/internal/websocket/internal_options.go
+++ b/internal/websocket/internal_options.go
@@ -86,13 +86,3 @@ func validRetryPolicy() Option {
 			return nil
 		})
 }
-
-func validHTTPClient() Option {
-	return optionFunc(
-		func(ws *Websocket) error {
-			if ws.client == nil {
-				return fmt.Errorf("%w: nil client", ErrMisconfiguredWS)
-			}
-			return nil
-		})
-}

--- a/internal/websocket/ws_test.go
+++ b/internal/websocket/ws_test.go
@@ -29,7 +29,6 @@ func TestNew(t *testing.T) {
 
 	wsDefaults := []Option{
 		WithIPv6(),
-		HTTPClient(nil),
 	}
 	tests := []struct {
 		description string
@@ -61,7 +60,6 @@ func TestNew(t *testing.T) {
 				}),
 				NowFunc(time.Now),
 				RetryPolicy(retry.Config{}),
-				HTTPClient(nil),
 			),
 			check: func(assert *assert.Assertions, c *Websocket) {
 				// URL Related
@@ -103,7 +101,6 @@ func TestNew(t *testing.T) {
 				}),
 				NowFunc(time.Now),
 				RetryPolicy(retry.Config{}),
-				HTTPClient(nil),
 			),
 			check: func(assert *assert.Assertions, c *Websocket) {
 				u, err := c.urlFetcher(context.Background())
@@ -162,7 +159,6 @@ func TestNew(t *testing.T) {
 					return nil
 				}),
 				RetryPolicy(retry.Config{}),
-				HTTPClient(nil),
 			),
 			check: func(assert *assert.Assertions, c *Websocket) {
 				if assert.NotNil(c.nowFunc) {
@@ -226,7 +222,6 @@ func TestMessageListener(t *testing.T) {
 		}),
 		NowFunc(time.Now),
 		RetryPolicy(retry.Config{}),
-		HTTPClient(nil),
 	)
 
 	assert.NoError(err)
@@ -258,7 +253,6 @@ func TestConnectListener(t *testing.T) {
 		}),
 		NowFunc(time.Now),
 		RetryPolicy(retry.Config{}),
-		HTTPClient(nil),
 	)
 
 	assert.NoError(err)
@@ -290,7 +284,6 @@ func TestDisconnectListener(t *testing.T) {
 		}),
 		NowFunc(time.Now),
 		RetryPolicy(retry.Config{}),
-		HTTPClient(nil),
 	)
 
 	assert.NoError(err)
@@ -322,7 +315,6 @@ func TestHeartbeatListener(t *testing.T) {
 		}),
 		NowFunc(time.Now),
 		RetryPolicy(retry.Config{}),
-		HTTPClient(nil),
 	)
 
 	assert.NoError(err)
@@ -344,7 +336,6 @@ func TestNextMode(t *testing.T) {
 		}),
 		NowFunc(time.Now),
 		RetryPolicy(retry.Config{}),
-		HTTPClient(nil),
 	}
 	tests := []struct {
 		description string


### PR DESCRIPTION
- instead of reusing the http client, recreate it for every ws connection attempt
- add a new option that force sets whatever HTTPClient fields we absolutely need, allowing us to make most required configuration changes happen all at once
- revert to https://github.com/xmidt-org/xmidt-agent/commit/254f9b98811a06940393667398af0e26c9bcb6b2 with  modifications for http.Transport option overrides