### PR TITLE
patch: fx group behavior differs between lists and non-lists

### DIFF
--- a/cmd/xmidt-agent/main.go
+++ b/cmd/xmidt-agent/main.go
@@ -266,6 +266,10 @@ func onStop(ws *websocket.Websocket, qos *qos.Handler, shutdowner fx.Shutdowner,
 		ws.Stop()
 		qos.Stop()
 		for _, c := range cancels {
+			if c == nil {
+				continue
+			}
+
 			c()
 		}
 


### PR DESCRIPTION
- the nil value for `Cancels []func() group:"cancels,flatten"` is discarded by fx (not used during dependency injection)
- but the nil value for `Cancel func() group:"cancels"` is used and not discarded
- currently this triggers panics when a wrp handler returns a nil for `Cancel func() group:"cancels"`
- this bug wasn't caught because we weren't returning errors when fx's lifecycle Start/Stop encountered a panic
  - #124 fixes our fx lifecycle