### PR TITLE
patch: update tests main_test and local default config

### DIFF
--- a/cmd/xmidt-agent/main.go
+++ b/cmd/xmidt-agent/main.go
@@ -272,10 +272,11 @@ func onStop(ws *websocket.Websocket, libParodus *libparodus.Adapter, qos *qos.Ha
 	logger = logger.Named("on_stop")
 
 	return func(context.Context) (err error) {
+		// err is set during a panic recovery in order to manually trigger
+		// the shutdown of the application by sending a signal to all open Done channels
 		defer func() {
 			if r := recover(); nil != r {
 				err = ErrLifecycleStopPanic
-				// fmt.Println(string(debug.Stack()))
 				logger.Error("stacktrace from panic", zap.String("stacktrace", string(debug.Stack())), zap.Any("panic", r), zap.Error(err))
 			}
 

--- a/cmd/xmidt-agent/main_test.go
+++ b/cmd/xmidt-agent/main_test.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"testing"
 	"time"
 
@@ -15,9 +14,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/xmidt-org/sallust"
-	"github.com/xmidt-org/xmidt-agent/internal/websocket"
-	"github.com/xmidt-org/xmidt-agent/internal/wrphandlers/qos"
-	"go.uber.org/fx"
 )
 
 func Test_provideCLI(t *testing.T) {
@@ -137,93 +133,6 @@ func Test_xmidtAgent(t *testing.T) {
 			defer cancel()
 			err = app.Stop(stopCtx)
 			require.NoError(err)
-		})
-	}
-}
-
-type badShutdown struct{}
-
-func (*badShutdown) Shutdown(...fx.ShutdownOption) error {
-	return errors.New("random shutdown error")
-}
-
-func Test_xmidtAgent_lifecycle(t *testing.T) {
-	tests := []struct {
-		description      string
-		lifeCycleOptions fx.Option
-		expectedErrs     []error
-	}{
-		// success cases
-		{
-			description: "panic in fx's Start triggered a successful rollback",
-			lifeCycleOptions: fx.Invoke(
-				func(LC fx.Lifecycle, ws *websocket.Websocket) {
-					var qos *qos.Handler
-					LC.Append(
-						fx.Hook{
-							// `qos` will trigger the panic during fx's Start,
-							// triggering the rollback
-							OnStart: onStart(nil, ws, qos, 0, sallust.Default()),
-						},
-					)
-				},
-			),
-			expectedErrs: []error{ErrLifecycleStartPanic},
-		},
-		{
-			description: "panic in fx's Stop triggered a successful manual shutdown",
-			lifeCycleOptions: fx.Invoke(
-				func(LC fx.Lifecycle, shutdowner fx.Shutdowner) {
-					var qos *qos.Handler
-					LC.Append(
-						fx.Hook{
-							// `qos` will trigger the panic during fx's Stop, manually triggering
-							// the shutdown of the application by sending a signal to all open Done channels
-							OnStop: onStop(&websocket.Websocket{}, qos, shutdowner, nil, sallust.Default()),
-						},
-					)
-				},
-			),
-			expectedErrs: []error{ErrLifecycleStopPanic},
-		},
-		// fail cases
-		{
-			description: "shutdown triggered and failed",
-			lifeCycleOptions: fx.Invoke(
-				func(LC fx.Lifecycle) {
-					var qos *qos.Handler
-					LC.Append(
-						fx.Hook{
-							// qos` will  trigger the panic during fx's Stop, manually triggering
-							// the shutdown of the application by sending a signal to all open Done channels
-							// &badShutdown{} will trigger the panic during fx's Stop, manually triggering
-							// the shutdown of the application by sending a signal to all open Done channels
-							OnStop: onStop(&websocket.Websocket{}, qos, &badShutdown{}, nil, sallust.Default()),
-						},
-					)
-				},
-			),
-			expectedErrs: []error{ErrLifecycleStopPanic, ErrLifecycleShutdownPanic},
-		},
-	}
-	args := []string{"-f", "xmidt_agent.yaml"}
-	for _, tc := range tests {
-		t.Run(tc.description, func(t *testing.T) {
-			assert := assert.New(t)
-			app := fx.New(provideAppOptions(args), tc.lifeCycleOptions)
-
-			// only run the program for	a few seconds to make sure it starts
-			startCtx, cancel := context.WithTimeout(context.Background(), time.Second)
-			defer cancel()
-			errs := app.Start(startCtx)
-			time.Sleep(time.Millisecond)
-
-			stopCtx, cancel := context.WithTimeout(context.Background(), time.Second)
-			defer cancel()
-			errs = errors.Join(errs, app.Stop(stopCtx))
-			for _, err := range tc.expectedErrs {
-				assert.ErrorIs(errs, err)
-			}
 		})
 	}
 }

--- a/cmd/xmidt-agent/xmidt_agent.yaml
+++ b/cmd/xmidt-agent/xmidt_agent.yaml
@@ -3,17 +3,6 @@
 
 websocket:
   url_path: api/v2/device
-xmidt_credentials:
-  url: ${TOKEN_URL}
-  file_name: crt.pem
-  file_permissions: 0777
-  http_client:
-    tls:
-      insecure_skip_verify: true
-      certificates: 
-        - certificate_file: crt.pem
-          key_file:         key.pem
-      min_version: 771 # 0x0303, the TLS 1.2 version uint16
 identity:
   device_id: mac:00deadbeef00
   serial_number: 1800deadbeef
@@ -26,22 +15,33 @@ operational_state:
   boot_time: "2024-02-28T01:04:27Z"
 xmidt_service:
   url: ${MAIL}
-# Optional
+# Optional (Examples)
+# xmidt_credentials:
+#   url: ${TOKEN_URL}
+#   file_name: crt.pem
+#   file_permissions: 0777
+#   http_client:
+#     tls:
+#       insecure_skip_verify: true
+#       certificates: 
+#         - certificate_file: crt.pem
+#           key_file:         key.pem
+#       min_version: 771 # 0x0303, the TLS 1.2 version uint16
 # storage:
 #   temporary: ~/local-rdk-testing/temporary
 #   durable: ~/local-rdk-testing/durable
 # mock_tr_181:
 #   enabled: true
 #   file_path: xmidt-agent/internal/wrphandlers/mocktr181/mock_tr181.json
-externals:
-  -
-    file: /home/schmidtw/sync/work/oss/xmidt-agent/main/xmidt-agent.main/cmd/xmidt-agent/wes.txt
-    as: properties
-    remap:
-      - from: Device.X_RDK_WebPA_Server.URL
-        to: XMIDT_URL
-      - from: Device.X_RDK_WebPA_DNSText.URL
-        to: DNS_URL
-      - from: Device.X_RDK_WebPA_TokenServer.URL
-        to: TOKEN_URL
+# externals:
+#   -
+#     file: ~/local-rdk-testing/durable/external.txt
+#     as: properties
+#     remap:
+#       - from: Device.X_RDK_WebPA_Server.URL
+#         to: XMIDT_URL
+#       - from: Device.X_RDK_WebPA_DNSText.URL
+#         to: DNS_URL
+      # - from: Device.X_RDK_WebPA_TokenServer.URL
+#         to: TOKEN_URL
 


### PR DESCRIPTION
- tests broke when #128 merged
- update docs
- https://github.com/xmidt-org/xmidt-agent/commit/1acb340ae73a86862edaab9ce0736b556bac89a6 fixed another issue created by #128, but the new config section `externals` caused main_test tests to fail since `/home/schmidtw/sync/work/oss/xmidt-agent/main/xmidt-agent.main/cmd/xmidt-agent/wes.txt` didn't exist.
- we're getting rid of our centralize lifecycle functions in main, so we're removing the lifecycle tests (the lifecycle tests were failing because multiple libparodus were trying to use  the same port)