### PR TITLE
feat: optimize qos queue trimming with `heap.Init()` (`O(n)`)

### DIFF
--- a/internal/wrphandlers/qos/internal_options.go
+++ b/internal/wrphandlers/qos/internal_options.go
@@ -33,8 +33,8 @@ func validatePriority() Option {
 func validateTieBreaker() Option {
 	return optionFunc(
 		func(h *Handler) error {
-			if h.tieBreaker == nil {
-				return errors.Join(fmt.Errorf("%w: nil tiebreak", ErrPriorityTypeInvalid), ErrMisconfiguredQOS)
+			if h.tieBreaker == nil || h.trimTieBreaker == nil {
+				return errors.Join(fmt.Errorf("%w: nil tiebreak/trimTieBreaker", ErrPriorityTypeInvalid), ErrMisconfiguredQOS)
 			}
 
 			return nil

--- a/internal/wrphandlers/qos/priority_queue.go
+++ b/internal/wrphandlers/qos/priority_queue.go
@@ -22,7 +22,7 @@ type priorityQueue struct {
 	// tieBreaker breaks any QualityOfService ties.
 	tieBreaker tieBreaker
 	// queueInTrimming indicates the queue is actively being trimmed, where messages with the lowest
-	// QualityOfService are prioritize and removed.
+	// QualityOfService are removed.
 	// Only used during `priorityQueue.trim()`.
 	queueInTrimming bool
 	// trimTieBreaker breaks any QualityOfService ties during queue trimming.
@@ -67,14 +67,13 @@ func (pq *priorityQueue) Enqueue(msg wrp.Message) error {
 	return nil
 }
 
-// trim removes messages with the lowest QualityOfService (taking `prioritizeOldest` into account)
-// until the queue no longer violates `maxQueueSize“.
+// trim removes messages with the lowest QualityOfService until the queue no longer violates `maxQueueSize“.
 func (pq *priorityQueue) trim() {
 	if pq.sizeBytes <= pq.maxQueueBytes {
 		return
 	}
 
-	// Prioritize messages with the lowest QualityOfService such that `pq.Pop()` will return the message with.
+	// Remove messages with the lowest QualityOfService.
 	pq.queueInTrimming = true
 	defer func() {
 		// Re-prioritize messages with the highest QualityOfService.
@@ -105,7 +104,7 @@ func (pq *priorityQueue) Less(i, j int) bool {
 	// Determine whether a tie breaker is required.
 	if iQOS != jQOS {
 		if pq.queueInTrimming {
-			// Prioritize messages with the lowest QualityOfService.
+			// Remove messages with the lowest QualityOfService.
 			return iQOS < jQOS
 		}
 

--- a/internal/wrphandlers/qos/qos.go
+++ b/internal/wrphandlers/qos/qos.go
@@ -38,6 +38,8 @@ type Handler struct {
 	priority PriorityType
 	// tieBreaker breaks any QualityOfService ties.
 	tieBreaker tieBreaker
+	// trimTieBreaker breaks any QualityOfService ties during queue trimming.
+	trimTieBreaker tieBreaker
 	// maxQueueBytes is the allowable max size of the qos' priority queue, based on the sum of all queued wrp message's payload.
 	maxQueueBytes int64
 	// MaxMessageBytes is the largest allowable wrp message payload.
@@ -130,6 +132,7 @@ func (h *Handler) serviceQOS(queue <-chan wrp.Message) {
 		maxQueueBytes:   h.maxQueueBytes,
 		maxMessageBytes: h.maxMessageBytes,
 		tieBreaker:      h.tieBreaker,
+		trimTieBreaker:  h.trimTieBreaker,
 	}
 	for {
 		select {


### PR DESCRIPTION
- 100% test cover for `internal/wrphandlers/qos`
- optimize `priorityQueue.trim()` to remove messages with the lowest qos value while using `trimTieBreaker` breaks any QualityOfService ties during queue trimming
- the compute cost of optimizing `priorityQueue.trim()` will be O(n)

More details on the compute cost of optimizing trim:

When we trim and we're looking to trim the least prioritized messages, then (right before removing messages) we need to call heap.Init() since the prioritization was changed. https://pkg.go.dev/container/heap#Init

The complexity of heap.Init() is O(n). Every time we need to trim, heap.Init() will be called twice (before and after trimming).

So the tax for trimming is: O(n) `[two heap.Init()  calls]` + O(n*log(n)) `[X calls to sort and remove messages from the queue]`