### PR TITLE
feat: optimize qos queue trimming without `heap.Init()` (`O(n*log(n)`)

### DIFF
--- a/internal/wrphandlers/qos/internal_options.go
+++ b/internal/wrphandlers/qos/internal_options.go
@@ -33,8 +33,8 @@ func validatePriority() Option {
 func validateTieBreaker() Option {
 	return optionFunc(
 		func(h *Handler) error {
-			if h.tieBreaker == nil {
-				return errors.Join(fmt.Errorf("%w: nil tiebreak", ErrPriorityTypeInvalid), ErrMisconfiguredQOS)
+			if h.tieBreaker == nil || h.trimTieBreaker == nil {
+				return errors.Join(fmt.Errorf("%w: nil tiebreak/trimTieBreaker", ErrPriorityTypeInvalid), ErrMisconfiguredQOS)
 			}
 
 			return nil

--- a/internal/wrphandlers/qos/priority_queue.go
+++ b/internal/wrphandlers/qos/priority_queue.go
@@ -49,7 +49,7 @@ func (pq *PriorityQueue) Dequeue() (wrp.Message, bool) {
 		}
 	}
 
-	// Keeps sizeBytes in sync since both queues point to the same data.
+	// Keep sizeBytes in sync since both queues point to the same data.
 	pq.trimQueue.sizeBytes = pq.sizeBytes
 
 	return itm.msg, ok
@@ -79,7 +79,7 @@ func (pq *PriorityQueue) trim() {
 		pq.trimQueue.trim()
 	}
 
-	// Keeps sizeBytes in sync since both queues point to the same data.
+	// Keep sizeBytes in sync since both queues point to the same data.
 	pq.sizeBytes = pq.trimQueue.sizeBytes
 	// Note, `PriorityQueue.Dequeue()' will eventually remove any trimmed items.
 }

--- a/internal/wrphandlers/qos/qos.go
+++ b/internal/wrphandlers/qos/qos.go
@@ -38,6 +38,8 @@ type Handler struct {
 	priority PriorityType
 	// tieBreaker breaks any QualityOfService ties.
 	tieBreaker tieBreaker
+	// trimTieBreaker breaks any QualityOfService ties during queue trimming.
+	trimTieBreaker tieBreaker
 	// maxQueueBytes is the allowable max size of the qos' priority queue, based on the sum of all queued wrp message's payload.
 	maxQueueBytes int64
 	// MaxMessageBytes is the largest allowable wrp message payload.
@@ -126,10 +128,11 @@ func (h *Handler) serviceQOS(queue <-chan wrp.Message) {
 	)
 
 	// create and manage the priority queue
-	pq := priorityQueue{
+	pq := PriorityQueue{
 		maxQueueBytes:   h.maxQueueBytes,
 		maxMessageBytes: h.maxMessageBytes,
 		tieBreaker:      h.tieBreaker,
+		trimQueue:       trimPriorityQueue{tieBreaker: h.trimTieBreaker},
 	}
 	for {
 		select {


### PR DESCRIPTION
- 100% test cover for internal/wrphandlers/qos
- optimize priorityQueue.trim() to remove messages with the lowest qos by leveraging two priority queues (1 prioritizing the highest QOS and the other prioritizing the lowest QOS)
- avoid the use of `heap.Init()` O(n)
- priorityQueue.trim() is O(n*log(n))
