### PR TITLE
patch: fix bad mock service name

### DIFF
--- a/cmd/xmidt-agent/default-config.yaml
+++ b/cmd/xmidt-agent/default-config.yaml
@@ -123,7 +123,7 @@ storage:
 mock_tr_181:
   enabled: true
   file_path: "mock_tr181.json"
-  service_name: "mock_config"
+  service_name: "config"
 xmidt_agent_crud:
   service_name: xmidt_agent
 qos:


### PR DESCRIPTION
- the value service name `mock_config` would not work if attempting to reach the mock_tr181 via webpa
- change the service name back to `config`