### PR TITLE
patch: update auth wrphandler to be webpa compliant

### DIFF
--- a/internal/wrphandlers/auth/handler.go
+++ b/internal/wrphandlers/auth/handler.go
@@ -87,11 +87,11 @@ func (h Handler) HandleWrp(msg wrp.Message) error {
 	response := msg
 	response.Destination = msg.Source
 	response.Source = h.source
-	response.ContentType = "text/plain"
-	response.Payload = []byte(fmt.Sprintf("Partner(s) '%s' not allowed.  Allowed: '%s'", got, want))
+	response.ContentType = "application/json"
 
 	code := int64(statusCode)
 	response.Status = &code
+	response.Payload = []byte(fmt.Sprintf(`{statusCode: %d, message:"Partner(s) '%s' not allowed.  Allowed: '%s'"}`, code, got, want))
 
 	sendErr := h.egress.HandleWrp(response)
 


### PR DESCRIPTION
- if we want webpa to use the device response status code, the device has to put the status code in its payload as a json https://github.com/xmidt-org/tr1d1um/blob/a8744affcbfa79ef19d018585a93c31843e0e7b2/translation/transport.go#L214-L216