### PR TITLE
patch: mocktr181, move the parameter name to the Tr181Payload's message when parameter is non-readable

### DIFF
--- a/internal/wrphandlers/mocktr181/handler.go
+++ b/internal/wrphandlers/mocktr181/handler.go
@@ -176,8 +176,7 @@ func (h Handler) get(names []string) (int64, []byte, error) {
 				})
 			default:
 				result.Parameters = append(result.Parameters, Parameter{
-					Name:    mockParameter.Name,
-					Message: "Invalid parameter name",
+					Message: fmt.Sprintf("Invalid parameter name: %s", mockParameter.Name),
 				})
 				statusCode = 520
 			}


### PR DESCRIPTION
- move the parameter name to the Tr181Payload's message when parameter is non-readable