### PR TITLE
patch: update docker xmidt-agent to run mocktr181 as service name `config`

### DIFF
--- a/.release/docker/config/config.yml
+++ b/.release/docker/config/config.yml
@@ -3,4 +3,4 @@
 mock_tr_181:
   enabled: true
   file_path: "/mock_tr181.json"
-  service_name: "mock_config"
+  service_name: "config"

--- a/.release/docker/config/example-config.yaml
+++ b/.release/docker/config/example-config.yaml
@@ -52,3 +52,4 @@ storage:
 mock_tr_181:
   enabled: true
   file_path: /mock_tr181.json
+  service_name: "config"


### PR DESCRIPTION
- update docker xmidt-agent to run mocktr181 as service name `config`