### PR TITLE
patch: add missing mocktr181's response fields

### DIFF
--- a/internal/wrphandlers/mocktr181/handler.go
+++ b/internal/wrphandlers/mocktr181/handler.go
@@ -167,7 +167,6 @@ func (h Handler) get(tr181 *Tr181Payload) (int64, []byte, error) {
 
 	for _, name := range tr181.Names {
 		for _, mockParameter := range h.parameters {
-			result.StatusCode = http.StatusOK
 			if !strings.HasPrefix(mockParameter.Name, name) {
 				continue
 			}
@@ -182,6 +181,7 @@ func (h Handler) get(tr181 *Tr181Payload) (int64, []byte, error) {
 					Message:    "Success",
 					Count:      1,
 				})
+				result.StatusCode = http.StatusOK
 			default:
 				result.Parameters = append(result.Parameters, Parameter{
 					Message: fmt.Sprintf("Invalid parameter name: %s", mockParameter.Name),

--- a/internal/wrphandlers/mocktr181/handler.go
+++ b/internal/wrphandlers/mocktr181/handler.go
@@ -73,6 +73,7 @@ type Parameter struct {
 	DataType   int                    `json:"dataType"`
 	Attributes map[string]interface{} `json:"attributes"`
 	Message    string                 `json:"message"`
+	Count      int                    `json"parameterCount"`
 }
 
 // New creates a new instance of the Handler struct.  The parameter egress is
@@ -178,6 +179,7 @@ func (h Handler) get(tr181 *Tr181Payload) (int64, []byte, error) {
 					DataType:   mockParameter.DataType,
 					Attributes: mockParameter.Attributes,
 					Message:    "Success",
+					Count:      1,
 				})
 			default:
 				result.Parameters = append(result.Parameters, Parameter{

--- a/internal/wrphandlers/mocktr181/handler.go
+++ b/internal/wrphandlers/mocktr181/handler.go
@@ -162,11 +162,12 @@ func (h Handler) get(tr181 *Tr181Payload) (int64, []byte, error) {
 	result := Tr181Payload{
 		Command:    tr181.Command,
 		Names:      tr181.Names,
-		StatusCode: http.StatusOK,
+		StatusCode: 520,
 	}
 
 	for _, name := range tr181.Names {
 		for _, mockParameter := range h.parameters {
+			result.StatusCode = http.StatusOK
 			if !strings.HasPrefix(mockParameter.Name, name) {
 				continue
 			}
@@ -188,10 +189,6 @@ func (h Handler) get(tr181 *Tr181Payload) (int64, []byte, error) {
 				result.StatusCode = 520
 			}
 		}
-	}
-
-	if len(result.Parameters) == 0 {
-		result.StatusCode = 520
 	}
 
 	payload, err := json.Marshal(result)

--- a/internal/wrphandlers/mocktr181/handler.go
+++ b/internal/wrphandlers/mocktr181/handler.go
@@ -60,6 +60,7 @@ type Tr181Payload struct {
 	Command    string      `json:"command"`
 	Names      []string    `json:"names"`
 	Parameters []Parameter `json:"parameters"`
+	StatusCode int         `json:"statusCode"`
 }
 
 type Parameters struct {
@@ -127,13 +128,13 @@ func (h Handler) HandleWrp(msg wrp.Message) error {
 
 	switch command {
 	case "GET":
-		statusCode, payloadResponse, err = h.get(payload.Names)
+		statusCode, payloadResponse, err = h.get(payload)
 		if err != nil {
 			return err
 		}
 
 	case "SET":
-		statusCode, payloadResponse, err = h.set(payload.Parameters)
+		statusCode, payloadResponse, err = h.set(payload)
 		if err != nil {
 			return err
 		}
@@ -156,11 +157,14 @@ func (h Handler) HandleWrp(msg wrp.Message) error {
 	return err
 }
 
-func (h Handler) get(names []string) (int64, []byte, error) {
-	result := Tr181Payload{}
-	statusCode := int64(http.StatusOK)
+func (h Handler) get(tr181 *Tr181Payload) (int64, []byte, error) {
+	result := Tr181Payload{
+		Command:    tr181.Command,
+		Names:      tr181.Names,
+		StatusCode: http.StatusOK,
+	}
 
-	for _, name := range names {
+	for _, name := range tr181.Names {
 		for _, mockParameter := range h.parameters {
 			if !strings.HasPrefix(mockParameter.Name, name) {
 				continue
@@ -173,14 +177,19 @@ func (h Handler) get(names []string) (int64, []byte, error) {
 					Value:      mockParameter.Value,
 					DataType:   mockParameter.DataType,
 					Attributes: mockParameter.Attributes,
+					Message:    "Success",
 				})
 			default:
 				result.Parameters = append(result.Parameters, Parameter{
 					Message: fmt.Sprintf("Invalid parameter name: %s", mockParameter.Name),
 				})
-				statusCode = 520
+				result.StatusCode = 520
 			}
 		}
+	}
+
+	if len(result.Parameters) == 0 {
+		result.StatusCode = 520
 	}
 
 	payload, err := json.Marshal(result)
@@ -188,17 +197,16 @@ func (h Handler) get(names []string) (int64, []byte, error) {
 		return http.StatusInternalServerError, payload, errors.Join(ErrInvalidResponsePayload, err)
 	}
 
-	if len(result.Parameters) == 0 {
-		statusCode = int64(520)
-	}
-
-	return statusCode, payload, nil
+	return int64(result.StatusCode), payload, nil
 }
 
-func (h Handler) set(parameters []Parameter) (int64, []byte, error) {
-	statusCode := http.StatusAccepted
-	result := Tr181Payload{}
-	for _, parameter := range parameters {
+func (h Handler) set(tr181 *Tr181Payload) (int64, []byte, error) {
+	result := Tr181Payload{
+		Command:    tr181.Command,
+		Names:      tr181.Names,
+		StatusCode: http.StatusOK,
+	}
+	for _, parameter := range tr181.Parameters {
 		for i := range h.parameters {
 			mockParameter := &h.parameters[i]
 			if mockParameter.Name != parameter.Name {
@@ -210,19 +218,19 @@ func (h Handler) set(parameters []Parameter) (int64, []byte, error) {
 				mockParameter.Value = parameter.Value
 				mockParameter.DataType = parameter.DataType
 				mockParameter.Attributes = parameter.Attributes
-
 				result.Parameters = append(result.Parameters, Parameter{
 					Name:       mockParameter.Name,
 					Value:      mockParameter.Value,
 					DataType:   mockParameter.DataType,
 					Attributes: mockParameter.Attributes,
+					Message:    "Success",
 				})
 			default:
 				result.Parameters = append(result.Parameters, Parameter{
 					Name:    mockParameter.Name,
 					Message: "Parameter is not writable",
 				})
-				statusCode = 520
+				result.StatusCode = 520
 			}
 		}
 	}
@@ -232,7 +240,7 @@ func (h Handler) set(parameters []Parameter) (int64, []byte, error) {
 		return http.StatusInternalServerError, payload, errors.Join(ErrInvalidResponsePayload, err)
 	}
 
-	return int64(statusCode), payload, nil
+	return int64(result.StatusCode), payload, nil
 }
 
 func (h Handler) loadFile() ([]MockParameter, error) {

--- a/internal/wrphandlers/mocktr181/handler_test.go
+++ b/internal/wrphandlers/mocktr181/handler_test.go
@@ -70,7 +70,7 @@ func TestHandler_HandleWrp(t *testing.T) {
 				Type:        wrp.SimpleEventMessageType,
 				Source:      "dns:tr1d1um.example.com/service/ignored",
 				Destination: "event:event_1/ignored",
-				Payload:     []byte("{\"command\":\"SET\",\"parameters\":[{\"name\":\"Device.WiFi.Radio.10000.Name\",\"dataType\":0,\"message\":\"Success\",\"value\":\"anothername\",\"attributes\":{\"notify\":0}}]}"),
+				Payload:     []byte("{\"command\":\"SET\",\"parameters\":[{\"name\":\"Device.WiFi.Radio.10000.Name\",\"dataType\":0,\"value\":\"anothername\",\"attributes\":{\"notify\":0}}]}"),
 			},
 			validate: func(a *assert.Assertions, msg wrp.Message, h *Handler) error {
 				a.Equal(int64(http.StatusAccepted), *msg.Status)

--- a/internal/wrphandlers/mocktr181/handler_test.go
+++ b/internal/wrphandlers/mocktr181/handler_test.go
@@ -70,7 +70,7 @@ func TestHandler_HandleWrp(t *testing.T) {
 				Type:        wrp.SimpleEventMessageType,
 				Source:      "dns:tr1d1um.example.com/service/ignored",
 				Destination: "event:event_1/ignored",
-				Payload:     []byte("{\"command\":\"SET\",\"parameters\":[{\"name\":\"Device.WiFi.Radio.10000.Name\",\"dataType\":0,\"value\":\"anothername\",\"attributes\":{\"notify\":0}}]}"),
+				Payload:     []byte("{\"command\":\"SET\",\"parameters\":[{\"name\":\"Device.WiFi.Radio.10000.Name\",\"dataType\":0,\"message\":\"Success\",\"value\":\"anothername\",\"attributes\":{\"notify\":0}}]}"),
 			},
 			validate: func(a *assert.Assertions, msg wrp.Message, h *Handler) error {
 				a.Equal(int64(http.StatusAccepted), *msg.Status)


### PR DESCRIPTION
- add the missing `statusCode` field to mocktr181's response payload
- add the expected values for the response fields `Command` and `Names`
- add missing `Success` message for successful `gets` and `patches`
- add missing `Count` field to mocktr181's response payload