### PR TITLE
patch: update mock181's `set` to check for non-writable params before updating params and for non-existing parameters

### DIFF
--- a/internal/wrphandlers/mocktr181/handler.go
+++ b/internal/wrphandlers/mocktr181/handler.go
@@ -212,6 +212,7 @@ func (h Handler) set(tr181 *Tr181Payload) (int64, []byte, error) {
 	)
 	// Check for any parameters that are not writable.
 	for _, parameter := range tr181.Parameters {
+		var found bool
 		for i := range h.parameters {
 			mockParameter := &h.parameters[i]
 			if mockParameter.Name != parameter.Name {
@@ -220,6 +221,7 @@ func (h Handler) set(tr181 *Tr181Payload) (int64, []byte, error) {
 
 			// Check whether mockParameter is writable.
 			if strings.Contains(mockParameter.Access, "w") {
+				found = true
 				// Add mockParameter to the list of parameters to be updated.
 				writableParams = append(writableParams, mockParameter)
 				continue
@@ -229,6 +231,14 @@ func (h Handler) set(tr181 *Tr181Payload) (int64, []byte, error) {
 			failedParams = append(failedParams, Parameter{
 				Name:    mockParameter.Name,
 				Message: "Parameter is not writable",
+			})
+		}
+
+		if !found {
+			// Requested parameter was not found.
+			failedParams = append(failedParams, Parameter{
+				Name:    parameter.Name,
+				Message: "Invalid parameter name",
 			})
 		}
 	}

--- a/internal/wrphandlers/mocktr181/handler.go
+++ b/internal/wrphandlers/mocktr181/handler.go
@@ -233,6 +233,7 @@ func (h Handler) set(tr181 *Tr181Payload) (int64, []byte, error) {
 		}
 	}
 
+	// Check if any parameters failed.
 	if len(failedParams) != 0 {
 		// If any parameter failed, then do not apply any changes to the parameters in writableParams.
 		writableParams = nil


### PR DESCRIPTION
During mock181's `set`:
- check for any non-writable params
- if any param is not writable, do not update any param
- add case when request param is not found