### PR TITLE
patch: update mock181's get, check for non-readable or non-existing parameters

### DIFF
--- a/internal/wrphandlers/mocktr181/handler.go
+++ b/internal/wrphandlers/mocktr181/handler.go
@@ -190,7 +190,7 @@ func (h Handler) get(tr181 *Tr181Payload) (int64, []byte, error) {
 				continue
 			}
 
-			// If requested parameter is a wild card and mockParameter is not readable,
+			// If the requested parameter is a wild card and is not readable,
 			// then continue and don't count it as a failure.
 			if name[len(name)-1] == '.' {
 				continue

--- a/internal/wrphandlers/mocktr181/handler_test.go
+++ b/internal/wrphandlers/mocktr181/handler_test.go
@@ -59,7 +59,7 @@ func TestHandler_HandleWrp(t *testing.T) {
 				var result Tr181Payload
 				err := json.Unmarshal(msg.Payload, &result)
 				a.NoError(err)
-				a.Equal(0, len(result.Parameters))
+				a.Equal(1, len(result.Parameters))
 				a.True(h.Enabled())
 				return nil
 			},


### PR DESCRIPTION
During mock181's get:
- check for any non-readable params
- if any param is not readable, do not return any parameters that succeeded
- add case when request param is not found
- update wildcard case