### PR TITLE
patch: mocktr181 returns 520 for unsupported commands

### DIFF
--- a/internal/wrphandlers/mocktr181/handler.go
+++ b/internal/wrphandlers/mocktr181/handler.go
@@ -142,7 +142,8 @@ func (h Handler) HandleWrp(msg wrp.Message) error {
 
 	default:
 		// currently only get and set are implemented for existing mocktr181
-		statusCode = http.StatusOK
+		statusCode = 520
+		payloadResponse = []byte(fmt.Sprintf(`{"message": "command %s is not support"}`, command))
 	}
 
 	response := msg

--- a/internal/wrphandlers/mocktr181/handler_test.go
+++ b/internal/wrphandlers/mocktr181/handler_test.go
@@ -93,6 +93,21 @@ func TestHandler_HandleWrp(t *testing.T) {
 
 				return nil
 			},
+		}, {
+			description:     "unknown command",
+			egressCallCount: 1,
+			msg: wrp.Message{
+				Type:        wrp.SimpleEventMessageType,
+				Source:      "dns:tr1d1um.example.com/service/ignored",
+				Destination: "event:event_1/ignored",
+				Payload:     []byte("{\"command\":\"FOOBAR\",\"parameters\":[{\"name\":\"Device.Bridging.MaxBridgeEntries\",\"dataType\":0,\"value\":\"anothername\",\"attributes\":{\"notify\":0}}]}"),
+			},
+			validate: func(a *assert.Assertions, msg wrp.Message, h *Handler) error {
+				a.Equal(int64(520), *msg.Status)
+				a.True(h.Enabled())
+
+				return nil
+			},
 		},
 	}
 	for _, tc := range tests {


### PR DESCRIPTION
- mocktr181 currently only supports `set` and `get` commands, return 520 for any other commands