### PR TITLE
patch: empty names field causes mockt181's GET to panic

### DIFF
--- a/internal/wrphandlers/mocktr181/handler.go
+++ b/internal/wrphandlers/mocktr181/handler.go
@@ -173,6 +173,10 @@ func (h Handler) get(tr181 *Tr181Payload) (int64, []byte, error) {
 	for _, name := range tr181.Names {
 		var found bool
 		for _, mockParameter := range h.parameters {
+			if name == "" {
+				continue
+			}
+
 			if !strings.HasPrefix(mockParameter.Name, name) {
 				continue
 			}


### PR DESCRIPTION
- empty names field causes mockt181's GET to panic (`name[len(name)-1] == '.'`)