### PR TITLE
patch: send response for failed Normify checks

### DIFF
--- a/internal/pubsub/pubsub.go
+++ b/internal/pubsub/pubsub.go
@@ -148,7 +148,7 @@ func (ps *PubSub) subscribe(route string, h wrpkit.Handler) (CancelFunc, error) 
 func (ps *PubSub) HandleWrp(msg wrp.Message) error {
 	normalized, dest, err := ps.normalize(&msg)
 	if err != nil {
-		return err
+		return errors.Join(err, wrpkit.ErrNotHandled)
 	}
 
 	// Unless the destination is this device, the message will be sent to the


### PR DESCRIPTION
- marked errors from pubsub normify as wrpkit.ErrNotHandled
- this will trigger responses for Normify errors