### PR TITLE
patch: mocktr181 failures halts scytale transactions

### DIFF
--- a/internal/wrphandlers/mocktr181/handler.go
+++ b/internal/wrphandlers/mocktr181/handler.go
@@ -119,7 +119,7 @@ func (h Handler) HandleWrp(msg wrp.Message) error {
 
 	err := json.Unmarshal(msg.Payload, &payload)
 	if err != nil {
-		return err
+		return errors.Join(err, wrpkit.ErrNotHandled)
 	}
 
 	var payloadResponse []byte
@@ -131,13 +131,13 @@ func (h Handler) HandleWrp(msg wrp.Message) error {
 	case "GET":
 		statusCode, payloadResponse, err = h.get(payload)
 		if err != nil {
-			return err
+			return errors.Join(err, wrpkit.ErrNotHandled)
 		}
 
 	case "SET":
 		statusCode, payloadResponse, err = h.set(payload)
 		if err != nil {
-			return err
+			return errors.Join(err, wrpkit.ErrNotHandled)
 		}
 
 	default:
@@ -155,8 +155,11 @@ func (h Handler) HandleWrp(msg wrp.Message) error {
 	response.Status = &statusCode
 
 	err = h.egress.HandleWrp(response)
+	if err != nil {
+		return errors.Join(err, wrpkit.ErrNotHandled)
+	}
 
-	return err
+	return nil
 }
 
 func (h Handler) get(tr181 *Tr181Payload) (int64, []byte, error) {

--- a/internal/wrphandlers/mocktr181/handler_test.go
+++ b/internal/wrphandlers/mocktr181/handler_test.go
@@ -108,6 +108,14 @@ func TestHandler_HandleWrp(t *testing.T) {
 
 				return nil
 			},
+		}, {
+			description: "no payload",
+			expectedErr: wrpkit.ErrNotHandled,
+			msg: wrp.Message{
+				Type:        wrp.SimpleEventMessageType,
+				Source:      "dns:tr1d1um.example.com/service/ignored",
+				Destination: "event:event_1/ignored",
+			},
 		},
 	}
 	for _, tc := range tests {


### PR DESCRIPTION
- during a failure, allow mocktr181 to end pending requests requiring a response