### PR TITLE
feat: update rdr codes for dropped message

### DIFF
--- a/internal/wrphandlers/qos/priority_queue_test.go
+++ b/internal/wrphandlers/qos/priority_queue_test.go
@@ -87,7 +87,12 @@ func testEnqueueDequeueAgePriority(t *testing.T) {
 			require.NoError(err)
 
 			for _, msg := range messages {
-				pq.Enqueue(msg)
+				err = pq.Enqueue(msg)
+				if len(msg.Payload) > pq.maxMessageBytes && pq.maxMessageBytes != 0 {
+					assert.Error(err)
+				} else {
+					assert.NoError(err)
+				}
 			}
 
 			actualMsg, ok := pq.Dequeue()
@@ -100,6 +105,7 @@ func testEnqueueDequeueAgePriority(t *testing.T) {
 }
 
 func testEnqueueDequeue(t *testing.T) {
+	var rdr = messageIsTooLarge
 	emptyLowQOSMsg := wrp.Message{
 		Destination:      "mac:00deadbeef00/config",
 		QualityOfService: 10,
@@ -132,7 +138,7 @@ func testEnqueueDequeue(t *testing.T) {
 	emptyXLargeCriticalQOSMsg := wrp.Message{
 		Destination:             "mac:00deadbeef04/config",
 		QualityOfService:        wrp.QOSCriticalValue,
-		RequestDeliveryResponse: &messageIsTooLarge,
+		RequestDeliveryResponse: &rdr,
 	}
 	enqueueSequenceTest := []wrp.Message{
 		mediumMediumQosMsg,
@@ -257,7 +263,12 @@ func testEnqueueDequeue(t *testing.T) {
 			require.NoError(err)
 
 			for _, msg := range tc.messages {
-				pq.Enqueue(msg)
+				err = pq.Enqueue(msg)
+				if len(msg.Payload) > pq.maxMessageBytes && pq.maxMessageBytes != 0 {
+					assert.Error(err)
+				} else {
+					assert.NoError(err)
+				}
 			}
 
 			if len(tc.expectedDequeueSequence) == 0 {

--- a/internal/wrphandlers/qos/qos.go
+++ b/internal/wrphandlers/qos/qos.go
@@ -155,14 +155,14 @@ func (h *Handler) serviceQOS(queue <-chan wrp.Message) {
 			}
 
 			// ErrMaxMessageBytes errrors are ignored.
-			_ = pq.Enqueue(msg)
+			pq.Enqueue(msg)
 		case <-ready:
 			// Previous Handler.wrpHandler has finished, check whether it
 			// was successful or not.
 			if msg, ok := <-failedMsg; ok {
 				// Delivery failed, re-enqueue message and try again later.
 				// ErrMaxMessageBytes errrors are ignored.
-				_ = pq.Enqueue(msg)
+				pq.Enqueue(msg)
 			}
 
 			ready, failedMsg = nil, nil

--- a/internal/wrphandlers/qos/qos.go
+++ b/internal/wrphandlers/qos/qos.go
@@ -155,14 +155,14 @@ func (h *Handler) serviceQOS(queue <-chan wrp.Message) {
 			}
 
 			// ErrMaxMessageBytes errrors are ignored.
-			pq.Enqueue(msg)
+			_ = pq.Enqueue(msg)
 		case <-ready:
 			// Previous Handler.wrpHandler has finished, check whether it
 			// was successful or not.
 			if msg, ok := <-failedMsg; ok {
 				// Delivery failed, re-enqueue message and try again later.
 				// ErrMaxMessageBytes errrors are ignored.
-				pq.Enqueue(msg)
+				_ = pq.Enqueue(msg)
 			}
 
 			ready, failedMsg = nil, nil


### PR DESCRIPTION
For dropped messages, dispose of the payload and update the rdr code to the following:
- rdr value of 4 for payloads too large
- rdr value of 102 for lower priority messages